### PR TITLE
set an argument count for service actions

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>DF</string>
+	<string>E0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>NSPrincipalClass</key>

--- a/QSServiceAction.m
+++ b/QSServiceAction.m
@@ -186,6 +186,7 @@ NSArray *QSServicesPlugin_applicationProviders() {
 		[serviceAction setProvider:self];
 		[serviceAction setDisplaysResult:YES];
 		[serviceAction setDetails:[NSString stringWithFormat:@"A service of %@",[serviceBundle lastPathComponent]]];
+        [serviceAction setArgumentCount:1];
 		
 		[newActions addObject:serviceAction];
 


### PR DESCRIPTION
Along with quicksilver/Quicksilver#1815, prevents you from being able to run a service action from the first pane.

On a related note: How and why are services showing up in the first pane?
